### PR TITLE
Remove noise from symbol list

### DIFF
--- a/Preferences/Symbol List Banned.tmPreferences
+++ b/Preferences/Symbol List Banned.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Symbol List Banned</string>
 	<key>scope</key>
-	<string>source.js meta.property.function entity.name.function</string>
+	<string>source.js meta.property.function entity.name.function, source.js entity.name.type.object, source.js entity.name.type.instance</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>


### PR DESCRIPTION
The default symbol list for the Javascript bundle contains a fair amount of noise. It includes objects, entities, functions and methods. This patch only leaves the functions in the Symbol list (the popup menu in the lower right of the window.)
