### PR TITLE
Fix situation where '=' operator for named functions wasn't scoped/style...

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -39,7 +39,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(?:\b([a-zA-Z_$][\w$]*)\s*=\s*)?\b(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*(\()</string>
+			<string>(?:\b([a-zA-Z_$][\w$]*)(\s*=\s*))?\b(function)(?:\s+([a-zA-Z_$][\w$]*))?\s*(\()</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -50,14 +50,19 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.function.js</string>
+					<string>keyword.operator.js</string>
 				</dict>
 				<key>3</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.js</string>
+					<string>storage.type.function.js</string>
 				</dict>
 				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.js</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.parameters.begin.js</string>


### PR DESCRIPTION
The pull request title says it all.  Very simple change.
