### PR TITLE
Exponential Notations should also be parsed as Numbers

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -103,7 +103,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?)+((e|E)[+-]?[0-9]+)?)\b</string>
+			<string>\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.js</string>
 		</dict>


### PR DESCRIPTION
I do not have TextMate and this is an untested commit that I am suggesting here as it is essentially the "upstream" for https://github.com/atom/language-javascript and because this is to solve the same issue detailed in the pull request 19 there - https://github.com/atom/language-javascript/pull/19

Could someone kindly verify for me that this is valid in TextMate too?

Thanks
