### PR TITLE
Remove legal ES6 keywords from invalid.illegal.js

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -439,7 +439,7 @@
 			<key>comment</key>
 			<string>Keywords reserved for future use but now are unused.</string>
 			<key>match</key>
-			<string>(?&lt;!\.|\$)\b(class|const|enum|export|extends|import|super)\b(?!\$)</string>
+			<string>(?&lt;!\.|\$)\b(enum)\b(?!\$)</string>
 			<key>name</key>
 			<string>invalid.illegal.js</string>
 		</dict>


### PR DESCRIPTION
`class`, `const`, `export`, `extends`, `import`, and `super` are no longer on [the list of reserved keywords in ES6](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reserved-words) and they're being used in transpired code these days. So, I think they should be taken off the illegal list.