### PR TITLE
Add support for missing ES6 features

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -1279,7 +1279,15 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?=[\p{L}\p{Nl}$_])</string>
+					<string>(?=[\p{L}\p{Nl}$_])|(\.\.\.)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.rest-parameters.js</string>
+						</dict>
+					</dict>
 					<key>comment</key>
 					<string>Matches valid argument, function and variable names.  To be thorough: https://github.com/mathiasbynens/mothereff.in/tree/master/js-variables</string>
 					<key>end</key>

--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -1445,6 +1445,12 @@
 					<key>name</key>
 					<string>keyword.operator.arithmetic.js</string>
 				</dict>
+				<dict>
+					<key>match</key>
+					<string>\.\.\.</string>
+					<key>name</key>
+					<string>keyword.operator.spread.js</string>
+				</dict>
 			</array>
 		</dict>
 		<key>strings</key>

--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -778,6 +778,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#function-call</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#operators</string>
 		</dict>
 		<dict>
@@ -1128,14 +1132,6 @@
 			<key>name</key>
 			<string>keyword.other.js</string>
 		</dict>
-		<dict>
-			<key>comment</key>
-			<string>Matches the function calls.</string>
-			<key>match</key>
-			<string>(?&lt;!\w)([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)(?=\()</string>
-			<key>name</key>
-			<string>meta.function-call.js</string>
-		</dict>
 	</array>
 	<key>repository</key>
 	<dict>
@@ -1235,6 +1231,48 @@
 				</dict>
 			</array>
 		</dict>
+		<key>function-call</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;!\w)([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)(\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>meta.function-call.js</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.function-call.begin.js</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Matches the function calls.</string>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.function-call.end.js</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
 		<key>function-params</key>
 		<dict>
 			<key>patterns</key>
@@ -1253,6 +1291,32 @@
 							<string>\G[\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*</string>
 							<key>name</key>
 							<string>variable.parameter.function.js</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#function-call</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#numbers</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#strings</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#comments</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#operators</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>(?&lt;!\.)\b(super|this)(?!\s*:)\b</string>
+							<key>name</key>
+							<string>variable.language.js</string>
 						</dict>
 					</array>
 				</dict>

--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -626,7 +626,21 @@
 			</array>
 		</dict>
 		<dict>
-			<key>captures</key>
+			<key>begin</key>
+			<string>(?x)
+                \b(class)
+                (?:
+                    \s+
+                    ([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)
+                )?
+                (?:
+                    \s+
+                    (extends)
+                    \s+
+                    (?:\b([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)\b(?![\(]))?
+                )?
+            </string>
+			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
@@ -649,23 +663,17 @@
 					<string>entity.other.inherited-class.js</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(?x)
-                \b(class)
-                (?:
-                    \s+
-                    ([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)
-                )?
-                (?:
-                    \s+
-                    (extends)
-                    \s+
-                    ([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)
-                )?
-                \s*($|(?=\{))
-            </string>
+			<key>end</key>
+			<string>\s*($|(?=\{))</string>
 			<key>name</key>
 			<string>meta.class.js</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#function-call</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -837,7 +837,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.|\$)\b(Array|Boolean|Date|Error|EvalError|Function|Number|Object|RangeError|ReferenceError|RegExp|String|SyntaxError|TypeError|URIError)\b(?!\$)</string>
+			<string>(?&lt;!\.|\$)\b(Array|Boolean|Date|Error|EvalError|Function|Map|Number|Object|Promise|Proxy|RangeError|ReferenceError|Reflect|RegExp|Set|String|SyntaxError|TypeError|URIError|WeakMap|WeakSet)\b(?!\$)</string>
 			<key>name</key>
 			<string>support.class.js</string>
 		</dict>


### PR DESCRIPTION
The following missing features were added to the grammar (all of which are from ES6 — 2015):

Adds support for the following missing built-in objects:

- [`Proxy`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-proxy-constructor)
- [`Map`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-map-constructor)
- [`Promise`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-constructor)
- [`Set`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-set-constructor)
- [`WeakMap`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-weakmap-constructor)
- [`WeakSet`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-weakset-objects)
- [`Reflect`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object)

---

Added support for [parameter default values](http://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions):

```js
function defaultValues(x, y = 7, z = something(), q = this.value) {
    return x + y + z;
}
defaultValues(1) === 50;
```

In order to allow other function calls inside the parameter list I had to extend the functionality of `meta.function-call.js`. It now works more like `meta.function-call.c` and `meta.function-call.swift`.

---

Added support for [rest parameters](http://www.ecma-international.org/ecma-262/6.0/#sec-function-definitions):

```js
function fun1(g, y, ...theArgs) {
  console.log(theArgs.length);
}
fun1(5, 6, 7); // 3
```

---

Added support for the new spread operator (for [arrays](http://www.ecma-international.org/ecma-262/6.0/#sec-array-initializer) and [lists](http://www.ecma-international.org/ecma-262/6.0/#sec-argument-lists)):

```js
var params = [ "hello", true, 7 ];
var other = [ 1, 2, ...params ]; // [ 1, 2, "hello", true, 7 ]
f(1, 2, ...params) === 9;
var str = "foo";
var chars = [ ...str ]; // [ "f", "o", "o" ]
```

---

Finally, added support for [class-inheritance-from expressions](http://www.ecma-international.org/ecma-262/6.0/#sec-class-definitions):

```js
var aggregation = (baseClass, ...mixins) => { ... }

class Blue { ... }
class Red { ... }
class Green { ... }

class Color extends aggregation(Blue, Red, Green) { ... }
```

---

This should bring this bundle up-to-date with the current specification. (Just in time for ES7 to land... 😆).