### PR TITLE
Fix class extending imported parent

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -660,7 +660,7 @@
                     \s+
                     (extends)
                     \s+
-                    ([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*)
+                    ([\p{L}\p{Nl}$_][\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}\.]*)
                 )?
                 \s*($|(?=\{))
             </string>


### PR DESCRIPTION
Classes can extend parent classes imported from modules, with syntax like

~~~javascript
class MyComponent extends React.Component …
~~~

The current grammar doesn’t allow parent class names containing periods.
This change lets them.