### PR TITLE
Fix `try` snippet

### DIFF
--- a/Snippets/try.tmSnippet
+++ b/Snippets/try.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>try {
 	$1
-} catch (${2:e) {
+} catch (${2:e}) {
 	$3
 }${4: finally {
 	$5


### PR DESCRIPTION
The `catch` parameter placeholder was missing the closing brace.