### PR TITLE
Add parameter highlighting for ES2015’s arrow functions.

### DIFF
--- a/Syntaxes/JavaScript.plist
+++ b/Syntaxes/JavaScript.plist
@@ -677,6 +677,104 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>(?x)
+				(?:([_$a-zA-Z][$\w]*)\s*(=)\s*)?	# optional assignment to identifier
+				(?=																# lookahead to:
+					(\( 														# open parenthesis
+						(?&gt;(?&gt;[^()]+)|\g&lt;-1&gt;)*				# anything except parens (atomic)
+					\))															# close parenthesis
+					\s*															# optional space
+					(=&gt;)														# arrow
+				)
+			</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.js</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>
+				Arrow function.
+				https://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions
+			</string>
+			<key>end</key>
+			<string>(?&lt;=\))\s*(=&gt;)</string>
+			<key>name</key>
+			<string>meta.function.js</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\G\(</string>
+					<key>name</key>
+					<string>punctuation.definition.parameters.begin.js</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\)(?=\s*=&gt;)</string>
+					<key>name</key>
+					<string>punctuation.definition.parameters.end.js</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function-params</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.js</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.js</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.js</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.function.js</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.arrow.js</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>
+				Arrow function, but without parentheses delimiting the parameters. Only valid when there is exactly one parameter without a default value.
+				https://www.ecma-international.org/ecma-262/6.0/#sec-arrow-function-definitions
+			</string>
+			<key>match</key>
+			<string>(?x)
+				(?:([_$a-zA-Z][$\w]*)\s*(=)\s*)?	# optional assignment to identifier
+				(?:(async)\s+)?										# optional "async" annotation
+				\b([_$a-zA-Z][$\w]*)							# single parameter name
+				\s*(=&gt;)														# optional space and arrow
+			</string>
+			<key>name</key>
+			<string>meta.function.js</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>(?&lt;=[\[=(?:+,!]|^|return|=&gt;|&amp;&amp;|\|\|)\s*(?=/[^/*+?].*/)</string>
 			<key>comment</key>
 			<string>Dont scope preceding whitespace as string.regex</string>
@@ -731,7 +829,7 @@
 			<key>comment</key>
 			<string>Matching as a capture group prevents false positives with other uses of :</string>
 			<key>end</key>
-			<string>([^:"'`\[\]{}()]*)(:)</string>
+			<string>([^:"`\[\]{}()]*)(:)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1008,10 +1106,8 @@
 			<string>invalid.illegal.js</string>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>\b(false|Infinity|NaN|null|true|undefined)\b</string>
-			<key>name</key>
-			<string>constant.language.js</string>
+			<key>include</key>
+			<string>#constants</string>
 		</dict>
 		<dict>
 			<key>match</key>
@@ -1239,6 +1335,13 @@
 				</dict>
 			</array>
 		</dict>
+		<key>constants</key>
+		<dict>
+			<key>match</key>
+			<string>\b(false|Infinity|NaN|null|true|undefined)\b</string>
+			<key>name</key>
+			<string>constant.language.js</string>
+		</dict>
 		<key>function-call</key>
 		<dict>
 			<key>patterns</key>
@@ -1315,6 +1418,10 @@
 						<dict>
 							<key>include</key>
 							<string>#numbers</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#constants</string>
 						</dict>
 						<dict>
 							<key>include</key>


### PR DESCRIPTION
Also: properly highlight constants like `null` and `false` when they are default values of parameters.

Before:
<img width="433" alt="screen shot 2017-11-07 at 11 18 55 am" src="https://user-images.githubusercontent.com/3450/32507629-98736188-c3ad-11e7-8031-8aa800f281bb.png">

After:
<img width="405" alt="screen shot 2017-11-07 at 11 19 31 am" src="https://user-images.githubusercontent.com/3450/32507634-9c0bfd3c-c3ad-11e7-8e0a-c97f06a1d2b7.png">


I borrowed portions of these patterns from this [JavaScript (Babel) language definition](https://github.com/gandm/language-babel/blob/master/grammars/Babel%20Language.json) for Atom. I do agree with #51, though, that ultimately the best solution would be to port that grammar over to TextMate; some of its scope names would need to be fixed, but it's probably less effort than bringing things over piecemeal.